### PR TITLE
Correct way to handler request parameters

### DIFF
--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -272,6 +272,11 @@ class OneLogin_Saml2_Logout_Request(object):
             else:
                 get_data = {}
 
+            if 'lowercase_urlencoding' in request_data.keys():
+                lowercase_urlencoding = request_data['lowercase_urlencoding']
+            else:
+                lowercase_urlencoding = False
+
             if self.__settings.is_strict():
                 res = OneLogin_Saml2_Utils.validate_xml(dom, 'saml-schema-protocol-2.0.xsd', self.__settings.is_debug_active())
                 if not isinstance(res, Document):
@@ -316,10 +321,10 @@ class OneLogin_Saml2_Logout_Request(object):
                 else:
                     sign_alg = get_data['SigAlg']
 
-                signed_query = 'SAMLRequest=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLRequest')
+                signed_query = 'SAMLRequest=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLRequest', lowercase_urlencoding=lowercase_urlencoding)
                 if 'RelayState' in get_data:
-                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState'))
-                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1))
+                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState', lowercase_urlencoding=lowercase_urlencoding))
+                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1, lowercase_urlencoding=lowercase_urlencoding))
 
                 if 'x509cert' not in idp_data or idp_data['x509cert'] is None:
                     raise Exception('In order to validate the sign on the Logout Request, the x509cert of the IdP is required')

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -82,6 +82,11 @@ class OneLogin_Saml2_Logout_Response(object):
             idp_entity_id = idp_data['entityId']
             get_data = request_data['get_data']
 
+            if 'lowercase_urlencoding' in request_data.keys():
+                lowercase_urlencoding = request_data['lowercase_urlencoding']
+            else:
+                lowercase_urlencoding = False
+
             if self.__settings.is_strict():
                 res = OneLogin_Saml2_Utils.validate_xml(self.document, 'saml-schema-protocol-2.0.xsd', self.__settings.is_debug_active())
                 if not isinstance(res, Document):
@@ -119,10 +124,10 @@ class OneLogin_Saml2_Logout_Response(object):
                 else:
                     sign_alg = get_data['SigAlg']
 
-                signed_query = 'SAMLResponse=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLResponse')
+                signed_query = 'SAMLResponse=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLResponse', lowercase_urlencoding=lowercase_urlencoding)
                 if 'RelayState' in get_data:
-                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState'))
-                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1))
+                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState', lowercase_urlencoding=lowercase_urlencoding))
+                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1, lowercase_urlencoding=lowercase_urlencoding))
 
                 if 'x509cert' not in idp_data or idp_data['x509cert'] is None:
                     raise Exception('In order to validate the sign on the Logout Response, the x509cert of the IdP is required')

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -1127,14 +1127,13 @@ class OneLogin_Saml2_Utils(object):
             return False
 
     @staticmethod
-    def get_encoded_parameter(get_data, name, default=None):
+    def get_encoded_parameter(get_data, name, default=None, lowercase_urlencoding=False):
         """Return an url encoded get parameter value
         Prefer to extract the original encoded value directly from query_string since url
         encoding is not canonical. The encoding used by ADFS 3.0 is not compatible with
         python's quote_plus (ADFS produces lower case hex numbers and quote_plus produces
         upper case hex numbers)
         """
-        lowercase_urlencoding = get_data.get('lowercase_urlencoding', False)
 
         if name not in get_data:
             return OneLogin_Saml2_Utils.case_sensitive_urlencode(default, lowercase_urlencoding)


### PR DESCRIPTION
Fixes a bug in the way `lowercase_urlencoding` gets passed down to `get_encoded_parameter`.
